### PR TITLE
Fixed #13

### DIFF
--- a/WemosEM-Mqtt-Power-Sensor/WemosEM/WemosEM.ino
+++ b/WemosEM-Mqtt-Power-Sensor/WemosEM/WemosEM.ino
@@ -80,6 +80,12 @@ void loop() {
 
   em_loop();
 
+  if (WiFi.status() != WL_CONNECTED) {
+    Serial.println("WiFi connection lost!");
+    ESP.restart();
+    delay(100);
+  }
+
   mqtt_client.loop();
   httpServer.handleClient(); //handles requests for the firmware update page
 

--- a/WemosEM-Mqtt-Power-Sensor/WemosEM/mqtt_wifi_serial_support.h
+++ b/WemosEM-Mqtt-Power-Sensor/WemosEM/mqtt_wifi_serial_support.h
@@ -200,7 +200,13 @@ void setupWifi() {
   wifiManager.setConfigPortalTimeout(180);
   wifiManager.setConnectTimeout(60);
   Serial.println(" Wifi " + wifi_hostname + ", password " + system_password);
-  wifiManager.autoConnect(wifi_hostname.c_str(), system_password.c_str());
+  if (!wifiManager.autoConnect(wifi_hostname.c_str(), system_password.c_str())) {
+    Serial.println("failed to connect and hit timeout (restart)");
+    delay(3000);
+    //reset and try again
+    ESP.restart();
+    delay(100);
+  }
 
 
   if (isSTA() && ipMode == 1) {


### PR DESCRIPTION
- Changes in mqtt_wifi_serial_support force to restart the ESP if no WiFi AP is found

- Changes in WemosEM.ino force to restart the ESP if the WiFi connection is lost and if so, the device enters in the first loop to connect.

This solves 2 problems:
- Does not found the AP at the beginning (for instance, electricity lost)
- Lost the AP connection in the middle of a beautiful day (for instance, you reboot manually the AP of home because it's a s**t)